### PR TITLE
Body margin top adjusted

### DIFF
--- a/app/assets/stylesheets/components/_body.scss
+++ b/app/assets/stylesheets/components/_body.scss
@@ -1,5 +1,5 @@
 .body{
-  margin-top: 68px;
+  margin-top: 44px;
   h1 {
   font-size: 28px !important;
   font-weight: bold;


### PR DESCRIPTION
Tem um espaço acima da div body que não conseguimos descobrir de onde vem. Então colocamos a margin top como 44px ao invés de 68px, que é a altura certa da navbar. Visualmente, deu certo!